### PR TITLE
make helm-google-suggest use helm-google

### DIFF
--- a/helm-google.el
+++ b/helm-google.el
@@ -216,20 +216,27 @@ Since the API this library uses is deprecated it is not very reliable."
     (volatile)))
 
 ;;;###autoload
-(defun helm-google ()
-  "Preconfigured `helm' : Google search."
-  (interactive)
-  (let ((google-referer "https://github.com/steckerhalter/helm-google")
-        (region (when (use-region-p)
-                  (buffer-substring-no-properties
-                   (region-beginning)
-                   (region-end))))
-        (helm-input-idle-delay 0.3))
-    (helm :sources 'helm-source-google
-          :prompt "Google: "
-          :input region
-          :buffer "*helm google*"
-          :history 'helm-google-input-history)))
+(defun helm-google ( &optional arg)
+    "Preconfigured `helm' : Google search."
+    (interactive)
+    (let ((google-referer "https://github.com/steckerhalter/helm-google")
+          (region
+           (if (not arg)
+               (when (use-region-p)
+                 (buffer-substring-no-properties
+                  (region-beginning)
+                  (region-end)))
+             arg))
+          (helm-input-idle-delay 0.3))
+      (helm :sources 'helm-source-google
+            :prompt "Google: "
+            :input region
+            :buffer "*helm google*"
+            :history 'helm-google-input-history)))
+  
+(add-to-list 'helm-google-suggest-actions
+    '("Helm-Google" . (lambda (candidate)
+      (helm-google candidate))))
 
 (provide 'helm-google)
 


### PR DESCRIPTION
1. I added an optional argument to the helm-google function that pre-inserts a search string.
2. I added helm-google as an candidate to helm-google-suggest-actions.

helm-google-suggest will now use helm-google as default option, while helm-google stays the same. 

It's still possible to open the google results in a browser with helm-google-suggest by choosing the action "Google Search" from the helm action menu or with "f2".

If you merge this request, you should probably mention in the "Readme" that the behavior of helm-google-suggest changes.