### PR TITLE
import helm-net for helm-google-suggest-actions

### DIFF
--- a/helm-google.el
+++ b/helm-google.el
@@ -29,6 +29,7 @@
 ;;; Code:
 
 (require 'helm)
+(require 'helm-net)
 (require 'google)
 
 (defgroup helm-google '()


### PR DESCRIPTION
package should import helm-net otherwise helm-google-suggest-actions is not declared in the scope of package issue #11 